### PR TITLE
Hotfix on publication.java

### DIFF
--- a/nuxeo-labs-we-publication/src/main/java/org/nuxeo/labs/we/Publication.java
+++ b/nuxeo-labs-we-publication/src/main/java/org/nuxeo/labs/we/Publication.java
@@ -83,18 +83,17 @@ public class Publication extends ModuleRoot {
                     while (rootSectionIterator.hasNext()) { // in case there are
                                                             // several
                                                             // sectionRoots
-                        query = query.concat(" 'OR ecm:parentId='");
+                        query = query.concat("' OR ecm:parentId='");
                         query = query.concat(rootSectionIterator.next().getId());
                     }
                     query = query.concat("')");
                     higherSections = session.query(query);
+                    log.warn(higherSections.size());
+                    
+                    latestPublicationsMap = getLatestPublicationMap(session, higherSections);
+                    ctx.setProperty("latestPublicationsMap", latestPublicationsMap);
+                    ctx.setProperty("higherSections", higherSections);
                 }
-                ctx.setProperty("higherSections", higherSections);
-                latestPublicationsMap = getLatestPublicationMap(session,
-                        higherSections);
-                ctx.setProperty("latestPublicationsMap", latestPublicationsMap);
-
-                log.warn(higherSections.size());
             } catch (ClientException e) {
                 log.error(e);
             }


### PR DESCRIPTION
- There is a problem with the concatenation of the request NXQL with the metadata "ecm:parentId"

- Fixed an exception "NullPointerException" thrown when we are not authenticated

Caused by: java.lang.NullPointerException
        at org.nuxeo.labs.we.Publication.getLatestPublicationMap(Publication.java:114)